### PR TITLE
Add build action for Visual Studio code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "love",
+            "type": "shell",
+            "command": "love",
+            "args": ["${workspaceFolder}"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
cmd+shift+b runs Love and if there is a `debug.debug()` opens in VS code terminal 

<img width="904" alt="Screen Shot 2019-08-30 at 12 44 00" src="https://user-images.githubusercontent.com/171730/64018324-0e425480-cb24-11e9-9bb6-dd9d312b2a15.png">
